### PR TITLE
Fix missing wishlist view migrations in v2.0 release

### DIFF
--- a/app/src/main/java/org/phenoapps/intercross/data/IntercrossDatabase.kt
+++ b/app/src/main/java/org/phenoapps/intercross/data/IntercrossDatabase.kt
@@ -9,12 +9,13 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.phenoapps.intercross.data.dao.*
 import org.phenoapps.intercross.data.migrations.MigrationV2MetaData
+import org.phenoapps.intercross.data.migrations.MigrationV3WishlistView
 import org.phenoapps.intercross.data.models.*
 
 @Database(entities = [Event::class, Parent::class,
     Wishlist::class, Settings::class, PollenGroup::class,
     Meta::class, MetadataValues::class],
-        views = [WishlistView::class], version = 2, exportSchema = true)
+        views = [WishlistView::class], version = 3, exportSchema = true)
 @TypeConverters(Converters::class)
 abstract class IntercrossDatabase : RoomDatabase() {
 
@@ -44,6 +45,7 @@ abstract class IntercrossDatabase : RoomDatabase() {
         private fun buildDatabase(ctx: Context): IntercrossDatabase {
             return Room.databaseBuilder(ctx, IntercrossDatabase::class.java, DATABASE_NAME)
                 .addMigrations(MigrationV2MetaData()) //v1 -> v2 migration added JSON based metadata
+                .addMigrations(MigrationV3WishlistView()) // v2 -> v3 migration for WishlistView
                 .setJournalMode(JournalMode.TRUNCATE) //truncate mode makes it easier to export/import database w/o having to manage WAL files.
                 .build()
         }

--- a/app/src/main/java/org/phenoapps/intercross/data/migrations/MigrationV2MetaData.kt
+++ b/app/src/main/java/org/phenoapps/intercross/data/migrations/MigrationV2MetaData.kt
@@ -74,29 +74,39 @@ class MigrationV2MetaData : Migration(1, 2) {
 
             with (it) {
 
-                moveToFirst()
+                if (moveToFirst()) {
 
-                do {
+                    do {
 
-                    //get indices for V1 static column string metadata and unique rowid
-                    val idIndex = getColumnIndexOrThrow("eid")
-                    val fruitsIndex = getColumnIndexOrThrow("fruits")
-                    val seedsIndex = getColumnIndexOrThrow("seeds")
-                    val flowersIndex = getColumnIndexOrThrow("flowers")
+                        //get indices for V1 static column string metadata and unique rowid
+                        val idIndex = getColumnIndexOrThrow("eid")
+                        val fruitsIndex = getColumnIndexOrThrow("fruits")
+                        val seedsIndex = getColumnIndexOrThrow("seeds")
+                        val flowersIndex = getColumnIndexOrThrow("flowers")
 
-                    //get actual string values, eid is used to update the row and
-                    //static metadata fields fruits/flowers/seeds will be encoded into a json string
-                    val eid = getIntOrNull(idIndex) ?: "-1"
-                    val fruits = getStringOrNull(fruitsIndex) ?: "0"
-                    val flowers = getStringOrNull(flowersIndex) ?: "0"
-                    val seeds = getStringOrNull(seedsIndex) ?: "0"
+                        //get actual string values, eid is used to update the row and
+                        //static metadata fields fruits/flowers/seeds will be encoded into a json string
+                        val eid = getIntOrNull(idIndex) ?: "-1"
+                        val fruits = getStringOrNull(fruitsIndex) ?: "0"
+                        val flowers = getStringOrNull(flowersIndex) ?: "0"
+                        val seeds = getStringOrNull(seedsIndex) ?: "0"
 
-                    //creates a json encoded string from the static columns
-                    execSQL("INSERT INTO metaValues (eid, metaId, value) VALUES (?, 1, ?)", arrayOf(eid, flowers))
-                    execSQL("INSERT INTO metaValues (eid, metaId, value) VALUES (?, 2, ?)", arrayOf(eid, seeds))
-                    execSQL("INSERT INTO metaValues (eid, metaId, value) VALUES (?, 3, ?)", arrayOf(eid, fruits))
+                        //creates a json encoded string from the static columns
+                        execSQL(
+                            "INSERT INTO metaValues (eid, metaId, value) VALUES (?, 1, ?)",
+                            arrayOf(eid, flowers)
+                        )
+                        execSQL(
+                            "INSERT INTO metaValues (eid, metaId, value) VALUES (?, 2, ?)",
+                            arrayOf(eid, seeds)
+                        )
+                        execSQL(
+                            "INSERT INTO metaValues (eid, metaId, value) VALUES (?, 3, ?)",
+                            arrayOf(eid, fruits)
+                        )
 
-                } while (moveToNext())
+                    } while (moveToNext())
+                }
             }
         }
     }

--- a/app/src/main/java/org/phenoapps/intercross/data/migrations/MigrationV3WishlistView.kt
+++ b/app/src/main/java/org/phenoapps/intercross/data/migrations/MigrationV3WishlistView.kt
@@ -1,0 +1,40 @@
+package org.phenoapps.intercross.data.migrations
+
+import android.database.sqlite.SQLiteException
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Room database migration class for going from version 2 to 3
+ * Version 3 ensures WishlistView is correctly established
+ */
+class MigrationV3WishlistView : Migration(2, 3) {
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        with(db) {
+            try {
+                beginTransaction()
+
+                createWishlistView()
+
+                setTransactionSuccessful()
+            } catch (e: SQLiteException) {
+                e.printStackTrace()
+            } finally {
+                endTransaction()
+            }
+        }
+    }
+
+    private fun SupportSQLiteDatabase.createWishlistView() {
+        // drop the old view
+        execSQL("DROP VIEW IF EXISTS WishlistView")
+
+        // create the new view with updated logic for wish progress calculation
+        execSQL("CREATE VIEW `WishlistView` AS SELECT DISTINCT femaleDbId as momId, femaleName as momName, maleDbId as dadId, maleName as dadName, wishMin, wishMax, wishType,\n" +
+                "\t(SELECT COUNT(*) \n" +
+                "\tFROM events as child\n" +
+                "\tWHERE (w.femaleDbId = child.mom and ((w.maleDbId = child.dad) or (child.dad = \"blank\" and w.maleDbId = \"-1\")))) as wishProgress\n" +
+                "from wishlist as w")
+    }
+}


### PR DESCRIPTION
The firebase crashlytics was loaded with crashes for missing migration for the WishlistView. The logic for wish progress calculation was changed after v1.0.2 release. Apks which were upgraded from a previous version crashed - fresh installs of v2.0 did not. 

Since we noticed the crashes after releasing the v2.0, created a new migration for the WishlistView, and bumped up the db version from 2 to 3.